### PR TITLE
Convert website to app or pwa

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -5,6 +5,11 @@
   <title data-translate-key="dashboardTitle">SafetyFirst – Admin Dashboard</title>
   <link rel="stylesheet" href="styles.css"/>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="manifest" href="manifest.webmanifest"/>
+  <meta name="theme-color" content="#2563eb"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <link rel="apple-touch-icon" href="icons/icon-192.png"/>
+  <script src="pwa.js" defer></script>
   <style>
     body.dashboard .highlight-ticker { display:none !important; }
     .nav-controls {

--- a/icons/README.txt
+++ b/icons/README.txt
@@ -1,0 +1,5 @@
+Place app icons here:
+- icon-192.png (192x192)
+- icon-512.png (512x512)
+- maskable-192.png (192x192 with safe padding)
+- maskable-512.png (512x512 with safe padding)

--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#2563eb">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <link rel="apple-touch-icon" href="icons/icon-192.png">
+  <script src="pwa.js" defer></script>
 
   <style>
     body {

--- a/index1.html
+++ b/index1.html
@@ -7,6 +7,11 @@
     <title>SafetyFirst - Disaster Preparedness for Students</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="manifest" href="manifest.webmanifest">
+    <meta name="theme-color" content="#2563eb">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" href="icons/icon-192.png">
+    <script src="pwa.js" defer></script>
 </head>
 <body>
   

--- a/kmap.html
+++ b/kmap.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8">
   <title>India Risk Map – Recent Hot-Spots</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css"/>
+  <link rel="manifest" href="manifest.webmanifest"/>
+  <meta name="theme-color" content="#2563eb"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <link rel="apple-touch-icon" href="icons/icon-192.png"/>
+  <script src="pwa.js" defer></script>
   <style>
     #map { height: 420px; width: 100%; }
   </style>

--- a/lang.html
+++ b/lang.html
@@ -2,6 +2,11 @@
 <html lang="en">
 <meta charset="utf-8">
 <title>Check CDN</title>
+<link rel="manifest" href="manifest.webmanifest">
+<meta name="theme-color" content="#2563eb">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<link rel="apple-touch-icon" href="icons/icon-192.png">
+<script src="pwa.js" defer></script>
 <body>
   <p id="out">Loading library…</p>
   <script src="https://cdn.jsdelivr.net/npm/@argos-translate/argos-translate/+esm" type="module"></script>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "SafetyFirst",
+  "short_name": "SafetyFirst",
+  "description": "Disaster preparedness learning for students.",
+  "start_url": "/index.html",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#2563eb",
+  "icons": [
+    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "icons/maskable-192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
+    { "src": "icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/pwa.js
+++ b/pwa.js
@@ -1,0 +1,26 @@
+// Register Service Worker and handle install prompt
+(async () => {
+  if ('serviceWorker' in navigator) {
+    try {
+      await navigator.serviceWorker.register('/service-worker.js', { scope: '/' });
+      console.log('[PWA] Service worker registered');
+    } catch (e) {
+      console.warn('[PWA] Service worker registration failed', e);
+    }
+  }
+
+  let deferredPrompt;
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    const btn = document.getElementById('install-app');
+    if (btn) btn.style.display = 'inline-flex';
+    btn?.addEventListener('click', async () => {
+      btn.style.display = 'none';
+      deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      console.log('[PWA] Install choice:', outcome);
+      deferredPrompt = null;
+    });
+  });
+})();

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,58 @@
+const CACHE_VERSION = 'v1';
+const APP_SHELL = [
+  'index.html',
+  'index1.html',
+  'dashboard.html',
+  'kmap.html',
+  'lang.html',
+  'styles.css',
+  'script.js',
+  'translation.js',
+  'manifest.webmanifest'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then((cache) => cache.addAll(APP_SHELL))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(
+      keys.map((key) => key !== CACHE_VERSION && caches.delete(key))
+    ))
+  );
+  self.clients.claim();
+});
+
+// Network-first for HTML, cache-first for others
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  const isHTML = request.destination === 'document' || (request.headers.get('accept') || '').includes('text/html');
+
+  if (isHTML) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) return cached;
+      return fetch(request).then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+        return response;
+      });
+    })
+  );
+});

--- a/text.html
+++ b/text.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html>
 <body>
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#2563eb">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <link rel="apple-touch-icon" href="icons/icon-192.png">
+  <script src="pwa.js" defer></script>
   <input id="q" placeholder="Ask something..." />
   <button onclick="ask()">Send</button>
   <pre id="out"></pre>


### PR DESCRIPTION
Add PWA functionality by introducing a web manifest, service worker, and PWA bootstrap script, and integrating them into all HTML pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-44b5c141-141b-4889-883d-cc4d770c1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44b5c141-141b-4889-883d-cc4d770c1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

